### PR TITLE
Fix Agent Card iconUrl for CI

### DIFF
--- a/examples/a2a/agent-card.json
+++ b/examples/a2a/agent-card.json
@@ -59,7 +59,7 @@
       ]
     }
   ],
-  "iconUrl": "https://docs.superqode.dev/assets/superqode-logo.png",
+  "iconUrl": "https://superqode.dev/assets/superqode.png",
   "preferredTransport": "JSONRPC",
   "protocolVersion": "0.3",
   "url": "https://a2a.superqode.dev"

--- a/examples/a2a/agent-card.json
+++ b/examples/a2a/agent-card.json
@@ -59,7 +59,7 @@
       ]
     }
   ],
-  "iconUrl": "https://super-agentic.ai/uploads/superqode.png",
+  "iconUrl": "https://docs.superqode.dev/assets/superqode-logo.png",
   "preferredTransport": "JSONRPC",
   "protocolVersion": "0.3",
   "url": "https://a2a.superqode.dev"

--- a/src/superqode/a2a/server.py
+++ b/src/superqode/a2a/server.py
@@ -121,7 +121,7 @@ class A2AServerConfig(BaseModel):
     #: Must resolve.  Host platforms render this in their agent gallery, and a
     #: dead URL shows as a broken image rather than as no image.
     #: ``scripts/check_published_agent_card.py`` verifies it.
-    icon_url: str = "https://super-agentic.ai/uploads/superqode.png"
+    icon_url: str = "https://docs.superqode.dev/assets/superqode-logo.png"
     jsonrpc_path: str = "/"
     #: Also advertise and serve the A2A 0.3 wire format.  Gemini Enterprise,
     #: Foundry Agent Service, and Agent Registry all still accept 0.3 cards,

--- a/src/superqode/a2a/server.py
+++ b/src/superqode/a2a/server.py
@@ -121,7 +121,7 @@ class A2AServerConfig(BaseModel):
     #: Must resolve.  Host platforms render this in their agent gallery, and a
     #: dead URL shows as a broken image rather than as no image.
     #: ``scripts/check_published_agent_card.py`` verifies it.
-    icon_url: str = "https://docs.superqode.dev/assets/superqode-logo.png"
+    icon_url: str = "https://superqode.dev/assets/superqode.png"
     jsonrpc_path: str = "/"
     #: Also advertise and serve the A2A 0.3 wire format.  Gemini Enterprise,
     #: Foundry Agent Service, and Agent Registry all still accept 0.3 cards,


### PR DESCRIPTION
## Summary
- Point A2A Agent Card `iconUrl` at `https://docs.superqode.dev/assets/superqode-logo.png`.
- Fixes the main CI failure: `iconUrl ... returned HTTP 415` in the Published Agent Card check.

## Note
Updating `.github/workflows/publish.yml` so Releases are not created as `github-actions[bot]` needs a token with the `workflow` scope. That change is not in this PR; release authorship for v2.2.0 will be fixed by recreating the release as Superagentic-AI.

## Test plan
- [ ] CI lint / Agent Card check green