### PR TITLE
security(a2a): A2ABreak P0 hardenings for card review and contextId

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,3 +5,7 @@ If you discover a security vulnerability, please report it privately.
 - Email: info@super-agentic.ai
 
 Please include steps to reproduce, impact, and any proposed mitigation.
+
+A2A protocol risks (spec-compliant adversary, not SuperQode product CVEs) are
+documented in [A2A protocol risks (A2ABreak)](docs/providers/a2a.md#a2a-protocol-risks-a2abreak)
+([arXiv:2609.10871](https://arxiv.org/abs/2609.10871)).

--- a/docs/cli-reference/connect-commands.md
+++ b/docs/cli-reference/connect-commands.md
@@ -267,13 +267,15 @@ superqode connect a2a [OPTIONS]
 | `--header NAME:VALUE` | Extra request header. Repeatable |
 | `--send TEXT` | Send one message after discovery |
 | `--save` / `--no-save` | Remember the connection (default: save) |
-| `--inspect` | Show the binding choice, skipped interfaces, advertised auth, and last HTTP request/response |
+| `--inspect` | Show the binding choice, skipped interfaces, advertised auth, card-review findings, and last HTTP request/response |
 | `--conformance` | Run SuperQode's client checks: fetch the card, speak a binding, complete one task |
 | `--no-send` | Skip the send check (with `--conformance` only) |
 | `--oauth` / `--no-oauth` | When a card requires OAuth, open a browser (default: open). `--no-oauth` still uses a stored token or client credentials |
 | `--logout` | Delete stored OAuth tokens for this origin and revoke them at the identity provider when it advertised `revocation_endpoint` |
 | `--tls-cert PATH` | Client certificate PEM for mutual TLS |
 | `--tls-key PATH` | Client certificate private key PEM |
+| `--allow-origin HOST` | Permit this Agent Card origin. Repeatable. Combined with `SUPERQODE_A2A_ALLOWED_ORIGINS` |
+| `--jws-trust-root PATH` | PEM or JWKS used to root Agent Card JWS. A signature without a trust root is not identity |
 | `--json` | Emit the card, binding, and optional task as JSON |
 
 ### Examples
@@ -317,7 +319,10 @@ Send is the chat with that agent and keeps the same `contextId` thread.
 Skill examples fill the message box. Use saves the connection in place; Back
 returns. y copies, r resends, Esc stops a wait. The screen lists skills and
 an inspect pane for the binding choice, advertised auth, and HTTP.
-`--inspect` is the CLI form of that pane. `--conformance` runs four client
+`--inspect` is the CLI form of that pane. It also prints Agent Card review
+findings that match SuperOptiX `agent-card-review`: unattested skill claims,
+an unsigned card, and (when JWS is present) that a signature authenticates
+the publisher, not skill capability. `--conformance` runs four client
 checks (card-fetch, card-shape, binding, send) and does not save the
 connection. A card SuperQode cannot speak prints the advertised interfaces
 and why each one was skipped.

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -58,6 +58,8 @@ Every `SUPERQODE_*` variable in one place. Most behavior is configurable per-har
 | `SUPERQODE_A2A_TLS_KEY` | path | unset | Private key PEM that pairs with `SUPERQODE_A2A_TLS_CERT`. |
 | `SUPERQODE_A2A_KEY_SECRET` | secret | unset | Signs and verifies customer API keys. Without it the server rejects every key. Generate with `superqode a2a-keys secret`. |
 | `SUPERQODE_A2A_REVOKED_KEYS` | comma-separated ids | unset | Key ids refused before their expiry. |
+| `SUPERQODE_A2A_ALLOWED_ORIGINS` | comma-separated hosts | unset | When set, `connect a2a` refuses Agent Card origins that are not on this list. `--allow-origin` adds entries for one invocation. |
+| `SUPERQODE_A2A_JWS_TRUST_ROOT` | path | unset | PEM or JWKS file used to root an Agent Card JWS. A signature without a trust root is not identity and is not authentication. |
 | `SUPERQODE_HARNESS` | path | unset | HarnessSpec YAML/JSON to load on start. |
 | `SUPERQODE_PIPY_DIR` | path | `~/.superqode/pipy` | Root for everything the PiPy harness writes. |
 | `SUPERQODE_PIPY_SESSION_DIR` | path | `<pipy dir>/sessions` | Where PiPy stores its session tree, one directory per working directory. |

--- a/docs/providers/a2a.md
+++ b/docs/providers/a2a.md
@@ -23,6 +23,8 @@ and they are separate from the A2A TCK result recorded under
 [Conformance](#conformance), which measures the server. A saved connection
 lives at `~/.superqode/a2a.json`. Later: `:a2a call <name>`.
 From the shell, `superqode connect a2a --inspect` prints the trace and
+the Agent Card review findings (unattested skills, unsigned or unrooted JWS,
+push claims, host mismatch, security scheme honesty).
 `superqode connect a2a --conformance` runs the checks. `--no-send` skips the
 task so a card-only check does not wait on a cold host. Repeatable
 `--header NAME:VALUE` flags are sent on every call. If the card declares an
@@ -207,7 +209,7 @@ registrable where only 0.3 is accepted; pass `legacy_v0_3=False` in
 is absent the SDK negotiates down to 0.3, so a 1.0 method name without the
 header is rejected. A 0.3 client needs no header.
 
-Each A2A `contextId` maps to one SuperQode Harness Protocol session, so later tasks in the same context reuse harness history while each A2A task keeps its own lifecycle and artifacts.
+Each A2A `contextId` maps to one SuperQode Harness Protocol session, so later tasks in the same context reuse harness history while each A2A task keeps its own lifecycle and artifacts. The A2A spec does not assign ownership of `contextId`. SuperQode binds each context to the caller principal (API key id, operator, opaque `X-SuperQode-Caller-Key`, or per-caller anonymous isolation) and refuses cross-principal reuse. Official SDK List, Get, Cancel, and Subscribe are scoped to that same principal.
 
 !!! note "0.3 compatibility covers JSON-RPC, not the legacy REST paths"
 
@@ -649,5 +651,39 @@ Preferred boundary for collaboration is **A2A**:
 2. **Inside a QM-style sandbox (optional packaging):** the [QM deployment-layer example](https://github.com/SuperagenticAI/superqode/tree/main/examples/qm-deployment-layer) shows how a tool/skill bootstrap can invoke `superqode harness run` under both outer command policy and SuperQode execution policy.
 
 Do not treat the QM example as official QM support. Prefer protocol-level interop fixtures: discovery, path-aware interface URLs, authentication, context continuity, artifacts, cancellation, approvals, and restart recovery. See also [Protocols and tools](../integrations/protocols-tools.md#a2a-and-multiplayer-computers).
+
+## A2A protocol risks (A2ABreak)
+
+[A2ABreak](https://arxiv.org/abs/2609.10871) (arXiv:2609.10871) is a
+specification-driven security analysis of A2A v1.0. It documents eleven
+protocol-level findings that a fully compliant adversary can exploit when the
+spec omits ownership, attestation, or integrity primitives. These are protocol
+risks, not SuperQode product CVEs.
+
+`superqode connect a2a` and `--inspect` report the same card-review findings
+as SuperOptiX `agent-card-review`:
+
+- `skills.attestation` (high): Skill claims are self-asserted. A2A 1.0 provides no attestation or capability challenge (A2ABreak protocol risk: Unattested Skill Claims).
+- `signature` (high): Card is unsigned. Signed cards are the A2A 1.0 mechanism for proving the card came from the domain owner.
+- `signature.trust` (medium): JWS authenticates the card publisher, not skill capability. A signature does not attest that advertised skills are truthful (A2ABreak protocol risk: JWS Key Trust Model Gap).
+
+A JWS is never treated as authentication. If a card is signed, configure a
+trust root with `--jws-trust-root` or `SUPERQODE_A2A_JWS_TRUST_ROOT` before
+treating the signature as rooted. An origin allowlist (`--allow-origin` or
+`SUPERQODE_A2A_ALLOWED_ORIGINS`) refuses unlisted discovery origins.
+
+`superqode serve a2a` hardens the server-side context surface:
+
+- Client-supplied `contextId` is principal-bound. Same-principal reuse is accepted. Cross-principal reuse is rejected.
+- Callers are isolated by API key id, operator token, opaque `X-SuperQode-Caller-Key`, or the address identity already used for rate limits. SuperQode does not use SuperOptiX caller cookies.
+- Official SDK List, Get, Cancel, and Subscribe resolve the owner from that principal, so one caller cannot read or cancel another caller's tasks.
+
+Push notifications stay disabled (`pushNotifications: false` on
+`A2AServerConfig`), which mitigates the unverified-webhook finding.
+
+Deferred to SuperOptiX and upstream A2A: protocol principal tokens, skill
+attestation standards, and webhook ownership proofs. Multi-hop workflows still
+drop the original caller. Do not forward an operator token or customer key to
+a downstream agent.
 
 See also [ACP Agents](acp.md), [MCP Tools](../configuration/mcp-config.md), and [Harness Protocol](../advanced/harness-protocol.md).

--- a/src/superqode/a2a/client.py
+++ b/src/superqode/a2a/client.py
@@ -214,6 +214,7 @@ class A2AClient:
             fallback = self.agent_url
 
         self.inspect.auth(auth_summary(data))
+        self._record_card_review(data)
         selected, skipped = _select_interface(interfaces, fallback)
         listed = interfaces if isinstance(interfaces, list) else []
         note = ""
@@ -236,6 +237,36 @@ class A2AClient:
             default_output_modes=data.get("defaultOutputModes", ["text"]),
         )
         return card, binding, version
+
+    def _record_card_review(self, data: dict) -> None:
+        """Record A2ABreak card-review findings. Never treat JWS as auth."""
+        from superqode.a2a.trust import (
+            origin_is_allowed,
+            parse_origin_allowlist,
+            record_card_review,
+            resolve_jws_trust_root,
+            review_agent_card,
+        )
+
+        allowed = getattr(self, "allowed_origins", None)
+        if allowed is None:
+            allowed = parse_origin_allowlist()
+        trust_root = getattr(self, "jws_trust_root", None)
+        if trust_root is None:
+            trust_root = resolve_jws_trust_root()
+        review = review_agent_card(
+            data,
+            origin=self.agent_url,
+            allowed_origins=tuple(allowed or ()),
+            jws_trust_root=str(trust_root or ""),
+        )
+        self._card_review = review
+        record_card_review(self.inspect, review)
+        if tuple(allowed or ()) and not origin_is_allowed(self.agent_url, tuple(allowed)):
+            raise A2AClientError(
+                f"Origin is not on the A2A allowlist: {self.agent_url}",
+                inspect=self.inspect,
+            )
 
     async def _ensure_interface(self) -> tuple[str, str, str]:
         if self._interface_url is None or self._binding is None or self._protocol_version is None:

--- a/src/superqode/a2a/conformance.py
+++ b/src/superqode/a2a/conformance.py
@@ -84,6 +84,8 @@ async def run_a2a_conformance(
     send: bool = True,
     http_client=None,
     timeout: float = 180.0,
+    allowed_origins: tuple[str, ...] = (),
+    jws_trust_root: str = "",
 ) -> A2AConformanceReport:
     """Run the four checks against ``settings.url``."""
     from superqode.a2a.client import A2AClient, A2AClientError
@@ -105,6 +107,10 @@ async def run_a2a_conformance(
         client_key=settings.key or None,
         timeout=timeout,
     ) as client:
+        if allowed_origins:
+            client.allowed_origins = allowed_origins
+        if jws_trust_root:
+            client.jws_trust_root = jws_trust_root
         try:
             card = await client.get_agent_card()
         except A2AClientError as exc:

--- a/src/superqode/a2a/context.py
+++ b/src/superqode/a2a/context.py
@@ -1,0 +1,132 @@
+"""Principal-bound A2A context ownership (A2ABreak).
+
+The A2A spec lets a client supply ``contextId`` and does not bind it to a
+caller. SuperQode binds each context to the caller principal (API key id,
+operator, opaque ``X-SuperQode-Caller-Key``, or per-caller anonymous
+isolation) and refuses cross-principal reuse.
+
+This is not the SuperOptiX cookie model. SuperQode already has API keys and
+an operator token. Anonymous callers can send an opaque caller key, otherwise
+they are isolated by the same address identity used for rate limits.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from superqode.a2a.keys import ANONYMOUS_TIER, OPERATOR_TIER
+from superqode.a2a.limits import caller_identity
+
+#: Opaque per-caller key for anonymous isolation. Not a SuperOptiX cookie.
+CALLER_HEADER = "x-superqode-caller-key"
+
+CONTEXT_OWNERSHIP_MESSAGE = (
+    "This contextId is bound to another caller. The A2A spec does not "
+    "assign context ownership; SuperQode binds each context to the "
+    "caller that created it."
+)
+
+
+class ContextOwnershipError(Exception):
+    """Client-supplied contextId belongs to a different principal."""
+
+    def __init__(self, context_id: str) -> None:
+        super().__init__(CONTEXT_OWNERSHIP_MESSAGE)
+        self.context_id = context_id
+
+
+class SuperQodeA2AUser:
+    """Caller principal presented to the official A2A task store.
+
+    ``user_name`` is the owner key the SDK uses for List, Get, Cancel, and
+    Subscribe. Anonymous callers still receive a non-empty name so they are
+    not collapsed into one shared bucket.
+    """
+
+    def __init__(self, name: str, *, authenticated: bool) -> None:
+        self._name = name
+        self._authenticated = authenticated
+
+    @property
+    def is_authenticated(self) -> bool:
+        return self._authenticated
+
+    @property
+    def user_name(self) -> str:
+        return self._name
+
+
+class ContextOwnerStore:
+    """In-process map of contextId to the principal that claimed it."""
+
+    def __init__(self) -> None:
+        self._owners: dict[str, str] = {}
+
+    def owner_of(self, context_id: str) -> str | None:
+        return self._owners.get(context_id)
+
+    def claim(
+        self,
+        context_id: str,
+        principal: str,
+        *,
+        stored_owner: str | None = None,
+    ) -> None:
+        """Bind ``context_id`` to ``principal``, or reject a cross-principal reuse."""
+        existing = self._owners.get(context_id) or (stored_owner or "").strip() or None
+        if existing:
+            self._owners[context_id] = existing
+            if existing != principal:
+                raise ContextOwnershipError(context_id)
+            return
+        self._owners[context_id] = principal
+
+
+def valid_caller_key(value: str) -> bool:
+    """Accept a short opaque token, the same shape SuperOptiX uses on the header."""
+    if not value or not (8 <= len(value) <= 128):
+        return False
+    return all(char.isalnum() or char in "-_" for char in value)
+
+
+def request_principal(decision: Any, request: Any) -> str:
+    """Resolve the principal for an HTTP request after access is decided."""
+    tier = str(getattr(decision, "tier", "") or ANONYMOUS_TIER)
+    key_id = str(getattr(decision, "key_id", "") or "")
+    if tier == OPERATOR_TIER:
+        return "operator"
+    if key_id:
+        return f"key:{key_id}"
+    header = ""
+    try:
+        header = (request.headers.get(CALLER_HEADER) or "").strip()
+    except AttributeError:
+        header = ""
+    if valid_caller_key(header):
+        return f"caller:{header}"
+    host = getattr(getattr(request, "client", None), "host", None)
+    try:
+        forwarded = request.headers.get("x-forwarded-for")
+    except AttributeError:
+        forwarded = None
+    return caller_identity("", host, forwarded)
+
+
+def caller_principal(context: Any) -> str:
+    """Return the principal recorded on an executor call context."""
+    call_context = getattr(context, "call_context", None)
+    state = getattr(call_context, "state", None) or {}
+    identity = str(state.get("identity") or "").strip()
+    if identity:
+        return identity
+    user = getattr(call_context, "user", None)
+    user_name = str(getattr(user, "user_name", "") or "").strip()
+    if user_name:
+        return user_name
+    key_id = str(state.get("key_id") or "").strip()
+    if key_id:
+        return f"key:{key_id}"
+    tier = str(state.get("tier") or ANONYMOUS_TIER)
+    if tier == OPERATOR_TIER:
+        return "operator"
+    return "anonymous:unknown"

--- a/src/superqode/a2a/inspect.py
+++ b/src/superqode/a2a/inspect.py
@@ -97,6 +97,10 @@ class InspectLog:
     def auth(self, summary: str, **detail: Any) -> None:
         self.add("auth", summary, **detail)
 
+    def trust(self, summary: str, **detail: Any) -> None:
+        """One Agent Card protocol-risk finding (A2ABreak)."""
+        self.add("trust", summary, **detail)
+
     def lines(self) -> list[str]:
         return [event.summary for event in self.events]
 

--- a/src/superqode/a2a/server.py
+++ b/src/superqode/a2a/server.py
@@ -22,8 +22,15 @@ if TYPE_CHECKING:
     from superqode.agent.loop import AgentConfig
     from superqode.harness import HarnessProtocolController, HarnessSessionRef, HarnessSpec
 
+from superqode.a2a.context import (
+    ContextOwnershipError,
+    ContextOwnerStore,
+    SuperQodeA2AUser,
+    caller_principal,
+    request_principal,
+)
 from superqode.a2a.keys import ANONYMOUS_TIER, AccessDecision, decide_access
-from superqode.a2a.limits import RateLimiter, RateLimitPolicy, caller_identity
+from superqode.a2a.limits import RateLimiter, RateLimitPolicy
 
 
 #: The version reported in the Agent Card.
@@ -197,6 +204,7 @@ class SuperQodeA2AExecutor:
         self.config = config
         self._sessions: dict[str, HarnessSessionRef] = {}
         self._task_sessions: dict[str, HarnessSessionRef] = {}
+        self._owners = ContextOwnerStore()
         self._session_lock = asyncio.Lock()
 
     async def execute(self, context: Any, event_queue: Any) -> None:
@@ -216,6 +224,17 @@ class SuperQodeA2AExecutor:
         await updater.start_work()
 
         user_input = context.get_user_input()
+        principal = caller_principal(context)
+        try:
+            self._owners.claim(
+                context_id,
+                principal,
+                stored_owner=self._stored_owner(context_id),
+            )
+        except ContextOwnershipError as exc:
+            await updater.failed(updater.new_agent_message([sdk["Part"](text=str(exc))]))
+            return
+
         if self._wants_shortlist(context, user_input):
             await self._answer_shortlist(
                 updater,
@@ -246,7 +265,11 @@ class SuperQodeA2AExecutor:
             )
             return
 
-        session = await self._session_for(context_id)
+        try:
+            session = await self._session_for(context_id, principal)
+        except ContextOwnershipError as exc:
+            await updater.failed(updater.new_agent_message([sdk["Part"](text=str(exc))]))
+            return
         self._task_sessions[task_id] = session
         artifact_id = f"superqode-{task_id}"
         content: list[str] = []
@@ -418,6 +441,10 @@ class SuperQodeA2AExecutor:
         sdk = _a2a_sdk()
         task_id = _required_id(context.task_id, "task")
         context_id = _required_id(context.context_id, "context")
+        principal = caller_principal(context)
+        owner = self._owners.owner_of(context_id) or self._stored_owner(context_id)
+        if owner and owner != principal:
+            return
         session = self._task_sessions.get(task_id)
         if session is not None:
             try:
@@ -428,7 +455,14 @@ class SuperQodeA2AExecutor:
                 pass
         await sdk["TaskUpdater"](event_queue, task_id, context_id).cancel()
 
-    async def _session_for(self, context_id: str) -> HarnessSessionRef:
+    def _stored_owner(self, context_id: str) -> str | None:
+        record = self.controller.store.get_session(f"a2a-{context_id}")
+        if record is None:
+            return None
+        owner = str((record.metadata or {}).get("a2a_owner") or "").strip()
+        return owner or None
+
+    async def _session_for(self, context_id: str, principal: str) -> HarnessSessionRef:
         from superqode.harness import HarnessCreateRequest
 
         async with self._session_lock:
@@ -437,7 +471,11 @@ class SuperQodeA2AExecutor:
                 return cached
 
             session_id = f"a2a-{context_id}"
-            if self.controller.store.get_session(session_id) is not None:
+            stored = self.controller.store.get_session(session_id)
+            if stored is not None:
+                stored_owner = str((stored.metadata or {}).get("a2a_owner") or "").strip()
+                if stored_owner and stored_owner != principal:
+                    raise ContextOwnershipError(context_id)
                 session = await self.controller.resume(session_id)
             else:
                 descriptor = self.controller.descriptors()[0]
@@ -448,7 +486,11 @@ class SuperQodeA2AExecutor:
                         model=self.config.model,
                         working_directory=self.config.working_directory.resolve(),
                         session_id=session_id,
-                        metadata={"transport": "a2a", "a2a_context_id": context_id},
+                        metadata={
+                            "transport": "a2a",
+                            "a2a_context_id": context_id,
+                            "a2a_owner": principal,
+                        },
                     )
                 )
             self._sessions[context_id] = session
@@ -600,11 +642,7 @@ class A2AServer:
                     content={"detail": f"Unauthorized: {decision.reason}"},
                     headers={"WWW-Authenticate": "Bearer"},
                 )
-            identity = caller_identity(
-                decision.key_id,
-                getattr(getattr(request, "client", None), "host", None),
-                request.headers.get("x-forwarded-for"),
-            )
+            identity = request_principal(decision, request)
             limit = limiter.check(identity, decision.tier)
             if not limit.allowed:
                 return sdk["JSONResponse"](
@@ -616,6 +654,7 @@ class A2AServer:
             # Carried on the scope so the call-context builder, and through it
             # the executor, can see which tier is asking.
             request.state.superqode_access = decision
+            request.state.superqode_identity = identity
             return await call_next(request)
 
         if self._task_engine is not None:
@@ -879,8 +918,17 @@ def _AccessContextBuilder(sdk: dict[str, Any]) -> Any:
         def build(self, request: Any) -> Any:
             context = super().build(request)
             decision = getattr(request.state, "superqode_access", None)
+            identity = str(getattr(request.state, "superqode_identity", "") or "").strip()
             if isinstance(decision, AccessDecision):
                 context.state.update(decision.to_state())
+            if not identity and isinstance(decision, AccessDecision):
+                identity = request_principal(decision, request)
+            if identity:
+                context.state["identity"] = identity
+                authenticated = bool(
+                    isinstance(decision, AccessDecision) and not decision.anonymous
+                )
+                context.user = SuperQodeA2AUser(identity, authenticated=authenticated)
             return context
 
     return _Builder()

--- a/src/superqode/a2a/trust.py
+++ b/src/superqode/a2a/trust.py
@@ -1,0 +1,280 @@
+"""Agent Card trust review for A2ABreak protocol risks.
+
+Findings use the same field names and issue text as SuperOptiX
+``agent-card-review`` so the two products report the same protocol risks.
+These are specification-compliant adversary issues, not SuperQode CVEs.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit
+
+ALLOWED_ORIGINS_ENV = "SUPERQODE_A2A_ALLOWED_ORIGINS"
+JWS_TRUST_ROOT_ENV = "SUPERQODE_A2A_JWS_TRUST_ROOT"
+
+# SuperOptiX agent-card-review wording, mirrored exactly.
+SKILLS_ATTESTATION_ISSUE = (
+    "Skill claims are self-asserted. A2A 1.0 provides no attestation or "
+    "capability challenge (A2ABreak protocol risk: Unattested Skill Claims)."
+)
+UNSIGNED_SIGNATURE_ISSUE = (
+    "Card is unsigned. Signed cards are the A2A 1.0 mechanism "
+    "for proving the card came from the domain owner."
+)
+JWS_TRUST_ISSUE = (
+    "JWS authenticates the card publisher, not skill capability. "
+    "A signature does not attest that advertised skills are truthful "
+    "(A2ABreak protocol risk: JWS Key Trust Model Gap)."
+)
+SECURITY_SCHEMES_ISSUE = "No security schemes declared, so callers cannot tell how to authenticate."
+
+
+@dataclass(frozen=True)
+class CardFinding:
+    """One Agent Card review finding."""
+
+    severity: str
+    field: str
+    issue: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"severity": self.severity, "field": self.field, "issue": self.issue}
+
+    def summary(self) -> str:
+        return f"{self.severity} {self.field}: {self.issue}"
+
+
+@dataclass(frozen=True)
+class CardReview:
+    """Scored list of protocol-risk findings for one Agent Card."""
+
+    findings: tuple[CardFinding, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"findings": [item.to_dict() for item in self.findings]}
+
+    @property
+    def fields(self) -> set[str]:
+        return {item.field for item in self.findings}
+
+
+def card_has_signature(card: dict[str, Any]) -> bool:
+    """True when the card carries a JWS ``signature`` or ``signatures`` field."""
+    return bool(card.get("signature") or card.get("signatures"))
+
+
+def parse_origin_allowlist(
+    values: tuple[str, ...] | list[str] | None = None,
+    *,
+    env: str | None = None,
+) -> tuple[str, ...]:
+    """CLI values first, then ``SUPERQODE_A2A_ALLOWED_ORIGINS``."""
+    items: list[str] = []
+    for value in values or ():
+        text = str(value).strip()
+        if text:
+            items.append(text)
+    source = env if env is not None else os.environ.get(ALLOWED_ORIGINS_ENV, "")
+    for part in source.split(","):
+        text = part.strip()
+        if text:
+            items.append(text)
+    return tuple(items)
+
+
+def resolve_jws_trust_root(
+    path: str | None = None,
+    *,
+    env: str | None = None,
+) -> str:
+    """CLI path first, then ``SUPERQODE_A2A_JWS_TRUST_ROOT``."""
+    if path and str(path).strip():
+        return str(path).strip()
+    source = env if env is not None else os.environ.get(JWS_TRUST_ROOT_ENV, "")
+    return str(source).strip()
+
+
+def origin_host(url: str) -> str:
+    """Hostname of an origin or interface URL, lowercased."""
+    text = (url or "").strip()
+    if not text:
+        return ""
+    if "://" not in text:
+        text = f"https://{text}"
+    return (urlsplit(text).hostname or "").lower()
+
+
+def origin_is_allowed(url: str, allowlist: tuple[str, ...] | list[str]) -> bool:
+    """Empty allowlist means every origin is allowed."""
+    if not allowlist:
+        return True
+    host = origin_host(url)
+    if not host:
+        return False
+    for item in allowlist:
+        allowed = (
+            origin_host(item)
+            if ("://" in item or item.startswith("."))
+            else item.lower().lstrip(".")
+        )
+        if item.startswith("."):
+            suffix = item.lower()
+            if host.endswith(suffix) or host == suffix.lstrip("."):
+                return True
+            continue
+        if host == allowed or host.endswith("." + allowed):
+            return True
+    return False
+
+
+def interface_hosts(card: dict[str, Any]) -> list[str]:
+    """Hosts advertised on ``url`` and ``supportedInterfaces``."""
+    hosts: list[str] = []
+    raw_url = card.get("url")
+    if isinstance(raw_url, str) and raw_url.strip():
+        host = origin_host(raw_url)
+        if host:
+            hosts.append(host)
+    interfaces = card.get("supportedInterfaces") or []
+    if isinstance(interfaces, list):
+        for item in interfaces:
+            if not isinstance(item, dict):
+                continue
+            host = origin_host(str(item.get("url") or ""))
+            if host:
+                hosts.append(host)
+    return hosts
+
+
+def review_agent_card(
+    card: dict[str, Any],
+    *,
+    origin: str = "",
+    allowed_origins: tuple[str, ...] | list[str] = (),
+    jws_trust_root: str = "",
+) -> CardReview:
+    """Return SuperOptiX-aligned findings plus SuperQode inspect extras.
+
+    A JWS, when present, is never treated as authentication or skill
+    attestation. A configured trust root only records that the operator
+    supplied one. It does not satisfy ``securitySchemes``.
+    """
+    del jws_trust_root  # presence is recorded by the caller; JWS is never auth
+    findings: list[CardFinding] = []
+
+    if card_has_signature(card):
+        findings.append(
+            CardFinding(severity="medium", field="signature.trust", issue=JWS_TRUST_ISSUE)
+        )
+    else:
+        findings.append(
+            CardFinding(severity="high", field="signature", issue=UNSIGNED_SIGNATURE_ISSUE)
+        )
+
+    if not card.get("securitySchemes"):
+        findings.append(
+            CardFinding(severity="medium", field="securitySchemes", issue=SECURITY_SCHEMES_ISSUE)
+        )
+    else:
+        unknown = _unknown_requirement_schemes(card)
+        if unknown:
+            listed = ", ".join(unknown)
+            findings.append(
+                CardFinding(
+                    severity="medium",
+                    field="securitySchemes",
+                    issue=(
+                        f"securityRequirements name scheme(s) {listed} that are "
+                        "not declared in securitySchemes."
+                    ),
+                )
+            )
+
+    skills = card.get("skills") or []
+    if skills:
+        findings.append(
+            CardFinding(
+                severity="high",
+                field="skills.attestation",
+                issue=SKILLS_ATTESTATION_ISSUE,
+            )
+        )
+
+    capabilities = card.get("capabilities") if isinstance(card.get("capabilities"), dict) else {}
+    if capabilities.get("pushNotifications") or capabilities.get("push_notifications"):
+        findings.append(
+            CardFinding(
+                severity="medium",
+                field="capabilities.pushNotifications",
+                issue=(
+                    "Card claims push notifications. Treat webhook URLs as "
+                    "untrusted. SuperQode serve a2a leaves pushNotifications "
+                    "false, which mitigates unverified webhooks."
+                ),
+            )
+        )
+
+    if origin:
+        advertised = interface_hosts(card)
+        discovery = origin_host(origin)
+        mismatched = [host for host in advertised if discovery and host != discovery]
+        if mismatched:
+            findings.append(
+                CardFinding(
+                    severity="medium",
+                    field="url.host",
+                    issue=(
+                        f"Interface host {', '.join(dict.fromkeys(mismatched))} "
+                        f"does not match the discovery origin {discovery}."
+                    ),
+                )
+            )
+        if allowed_origins and not origin_is_allowed(origin, tuple(allowed_origins)):
+            findings.append(
+                CardFinding(
+                    severity="high",
+                    field="origin.allowlist",
+                    issue=f"Origin {origin} is not on the configured A2A allowlist.",
+                )
+            )
+
+    return CardReview(findings=tuple(findings))
+
+
+def record_card_review(inspect_log: Any, review: CardReview) -> None:
+    """Append each finding to an InspectLog as a ``trust`` event."""
+    if inspect_log is None:
+        return
+    for finding in review.findings:
+        inspect_log.add(
+            "trust",
+            finding.summary(),
+            severity=finding.severity,
+            field=finding.field,
+            issue=finding.issue,
+        )
+
+
+def _unknown_requirement_schemes(card: dict[str, Any]) -> list[str]:
+    schemes = card.get("securitySchemes")
+    if not isinstance(schemes, dict):
+        return []
+    declared = {str(name) for name in schemes}
+    raw = card.get("securityRequirements") or card.get("security") or []
+    if not isinstance(raw, list):
+        return []
+    unknown: list[str] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        mapping = item.get("schemes") if isinstance(item.get("schemes"), dict) else item
+        if not isinstance(mapping, dict):
+            continue
+        for name in mapping:
+            key = str(name)
+            if key and key not in declared and key != "schemes" and key not in unknown:
+                unknown.append(key)
+    return unknown

--- a/src/superqode/commands/a2a_connect.py
+++ b/src/superqode/commands/a2a_connect.py
@@ -32,13 +32,29 @@ def connect_a2a_agent(
     logout: bool = False,
     cert: str | None = None,
     key: str | None = None,
+    allow_origins: tuple[str, ...] | list[str] = (),
+    jws_trust_root: str | None = None,
 ) -> int:
     """Fetch the Agent Card, print what it advertises, optionally send one message."""
+    from superqode.a2a.trust import (
+        origin_is_allowed,
+        parse_origin_allowlist,
+        resolve_jws_trust_root,
+    )
+
     settings = resolve_settings(url, token, headers, cert=cert, key=key)
+    allowed = parse_origin_allowlist(tuple(allow_origins or ()))
+    trust_root = resolve_jws_trust_root(jws_trust_root)
     if not settings.configured:
         return _fail(
             "No A2A agent URL is configured.",
             f"Pass --url or set {URL_ENV}.",
+            json_output=json_output,
+        )
+
+    if allowed and not origin_is_allowed(settings.url, allowed):
+        return _fail(
+            f"Origin is not on the A2A allowlist: {settings.url}",
             json_output=json_output,
         )
 
@@ -52,6 +68,8 @@ def connect_a2a_agent(
             inspect=inspect,
             send=send,
             json_output=json_output,
+            allowed_origins=allowed,
+            jws_trust_root=trust_root,
         )
 
     try:
@@ -61,6 +79,8 @@ def connect_a2a_agent(
                 message=message,
                 interactive=not json_output,
                 oauth=oauth,
+                allowed_origins=allowed,
+                jws_trust_root=trust_root,
             )
         )
     except Exception as exc:  # noqa: BLE001 - report any transport or protocol failure
@@ -136,12 +156,22 @@ def _run_conformance(
     inspect: bool,
     send: bool,
     json_output: bool,
+    allowed_origins: tuple[str, ...] = (),
+    jws_trust_root: str = "",
 ) -> int:
     """Run the client checks. A check does not save the connection."""
     from superqode.a2a.conformance import render_a2a_conformance, run_a2a_conformance
 
     try:
-        report = asyncio.run(run_a2a_conformance(settings, message=message, send=send))
+        report = asyncio.run(
+            run_a2a_conformance(
+                settings,
+                message=message,
+                send=send,
+                allowed_origins=allowed_origins,
+                jws_trust_root=jws_trust_root,
+            )
+        )
     except Exception as exc:  # noqa: BLE001 - report any transport or protocol failure
         return _fail(
             f"Could not check the A2A agent at {settings.url}: {exc}",
@@ -177,6 +207,8 @@ async def _probe(
     message: str | None,
     interactive: bool = True,
     oauth: bool = True,
+    allowed_origins: tuple[str, ...] = (),
+    jws_trust_root: str = "",
 ) -> dict[str, Any]:
     from superqode.a2a.client import A2AClient, A2AClientError
 
@@ -188,6 +220,8 @@ async def _probe(
         client_key=settings.key or None,
         timeout=180.0,
     ) as client:
+        client.allowed_origins = allowed_origins
+        client.jws_trust_root = jws_trust_root
         try:
             return await _probe_with(
                 client,
@@ -247,6 +281,9 @@ async def _probe_with(
         "interfaces": list(card.supported_interfaces),
         "inspect": client.inspect.to_dict(),
     }
+    review = getattr(client, "_card_review", None)
+    if review is not None:
+        payload["card_review"] = review.to_dict()
     if message:
         from superqode.a2a.reply import task_reply
 
@@ -284,6 +321,20 @@ def _render(
         click.echo(f"\nSkills ({len(skills)}):")
         for skill in skills:
             click.echo(f"  {skill['id']:<24} {skill['name']}")
+        click.echo(
+            "Skill claims are self-asserted. A2A 1.0 provides no "
+            "attestation or capability challenge (A2ABreak protocol risk: "
+            "Unattested Skill Claims)."
+        )
+    findings = (result.get("card_review") or {}).get("findings") or []
+    if findings:
+        click.echo("\nCard review:")
+        for item in findings:
+            if not isinstance(item, dict):
+                continue
+            click.echo(
+                f"  {item.get('severity', '')} {item.get('field', '')}: {item.get('issue', '')}"
+            )
     task = result.get("task")
     if task:
         click.echo(f"\nTask:       {task['id']}  {task['state']}")
@@ -314,6 +365,10 @@ def _render_inspect(inspect: dict[str, Any] | None) -> None:
             loc = skipped.get("url") or "(no url)"
             reason = skipped.get("reason") or "unusable"
             click.echo(f"    skip {binding} {version} at {loc}: {reason}")
+        if event.get("kind") == "trust":
+            issue = detail.get("issue")
+            if issue and issue not in str(event.get("summary") or ""):
+                click.echo(f"    {issue}")
         body = detail.get("body")
         if body:
             for line in str(body).splitlines()[:12]:

--- a/src/superqode/commands/connect.py
+++ b/src/superqode/commands/connect.py
@@ -106,7 +106,7 @@ def connect_uhp(base_url, api_key, harness, max_output_tokens, save, json_output
     "--inspect",
     "inspect",
     is_flag=True,
-    help="Show the binding choice, skipped interfaces, and last HTTP request/response",
+    help="Show the binding choice, skipped interfaces, card-review findings, and last HTTP request/response",
 )
 @click.option(
     "--conformance",
@@ -140,6 +140,19 @@ def connect_uhp(base_url, api_key, harness, max_output_tokens, save, json_output
     metavar="PATH",
     help="Client certificate private key PEM for mutual TLS",
 )
+@click.option(
+    "--allow-origin",
+    "allow_origins",
+    multiple=True,
+    metavar="HOST",
+    help="Permit this Agent Card origin. Repeatable. If any are set (or SUPERQODE_A2A_ALLOWED_ORIGINS), other origins are refused.",
+)
+@click.option(
+    "--jws-trust-root",
+    "jws_trust_root",
+    metavar="PATH",
+    help="PEM or JWKS file used to root Agent Card JWS. A signature without a trust root is not identity.",
+)
 @click.option("--json", "json_output", is_flag=True, help="Emit JSON")
 def connect_a2a(
     url,
@@ -154,6 +167,8 @@ def connect_a2a(
     logout,
     tls_cert,
     tls_key,
+    allow_origins,
+    jws_trust_root,
     json_output,
 ):
     """Connect to an A2A agent from its Agent Card.
@@ -184,6 +199,8 @@ def connect_a2a(
             logout=logout,
             cert=tls_cert,
             key=tls_key,
+            allow_origins=allow_origins,
+            jws_trust_root=jws_trust_root,
             json_output=json_output,
         )
     )

--- a/src/superqode/widgets/a2a_connect.py
+++ b/src/superqode/widgets/a2a_connect.py
@@ -1013,6 +1013,15 @@ class A2AConnectScreen(Screen[A2AConnectResult | None]):
             skills.append("Skills  ", style="#a78bfa")
             skills.append(", ".join(row.name for row in self._rows), style="#d4d4d4")
             log.write(skills)
+            note = Text()
+            note.append("Trust  ", style="#a78bfa")
+            note.append(
+                "Skill claims are self-asserted. A2A 1.0 provides no "
+                "attestation or capability challenge (A2ABreak protocol risk: "
+                "Unattested Skill Claims).",
+                style="#c8c8c8",
+            )
+            log.write(note)
         if self._catalogue_only:
             note = Text()
             note.append("Catalogue  ", style="bold #c4b5fd")

--- a/tests/test_a2a_bridge.py
+++ b/tests/test_a2a_bridge.py
@@ -1405,3 +1405,91 @@ def test_a2a_cli_gates_remote_binding_by_what_it_exposes():
     )
     assert harness_without_token.exit_code == 1
     assert "requires --token" in harness_without_token.output
+
+
+def test_context_id_reuse_is_bound_to_the_caller(tmp_path: Path):
+    """Same API key may resume a context. A different key may not (A2ABreak)."""
+    from superqode.a2a.keys import mint_key
+
+    secret = "context-ownership-secret"
+    key_a, _ = mint_key("Alice", secret=secret)
+    key_b, _ = mint_key("Bob", secret=secret)
+    server, session_ids = _server(tmp_path)
+    configured = A2AServer(
+        server.controller,
+        A2AServerConfig(
+            provider="test",
+            model="test",
+            url="http://127.0.0.1:8000",
+            working_directory=Path("."),
+            task_store_path=tmp_path / "tasks-owners.sqlite3",
+            key_secret=secret,
+        ),
+    )
+    client = TestClient(configured.app)
+    first = client.post(
+        "/message:send",
+        headers={"A2A-Version": "1.0", "Authorization": f"Bearer {key_a}"},
+        json=_request("first", context_id="shared-context"),
+    )
+    assert first.status_code == 200, first.text
+    assert first.json()["task"]["status"]["state"] == "TASK_STATE_COMPLETED"
+
+    reuse = client.post(
+        "/message:send",
+        headers={"A2A-Version": "1.0", "Authorization": f"Bearer {key_a}"},
+        json=_request("second", context_id="shared-context"),
+    )
+    assert reuse.status_code == 200, reuse.text
+    assert session_ids[0] == session_ids[1]
+
+    stolen = client.post(
+        "/message:send",
+        headers={"A2A-Version": "1.0", "Authorization": f"Bearer {key_b}"},
+        json=_request("steal", context_id="shared-context"),
+    )
+    assert stolen.status_code == 200, stolen.text
+    body = stolen.json()
+    state = body["task"]["status"]["state"]
+    assert state == "TASK_STATE_FAILED"
+    blob = json.dumps(body)
+    assert "bound to another caller" in blob
+    assert len(session_ids) == 2
+
+
+def test_get_task_is_scoped_to_the_caller_principal(tmp_path: Path):
+    """Official SDK List/Get/Cancel/Subscribe key tasks by call-context user."""
+    from superqode.a2a.keys import mint_key
+
+    secret = "task-scope-secret"
+    key_a, _ = mint_key("Alice", secret=secret)
+    key_b, _ = mint_key("Bob", secret=secret)
+    server, _ = _server(tmp_path)
+    configured = A2AServer(
+        server.controller,
+        A2AServerConfig(
+            provider="test",
+            model="test",
+            url="http://127.0.0.1:8000",
+            working_directory=Path("."),
+            task_store_path=tmp_path / "tasks-scope.sqlite3",
+            key_secret=secret,
+        ),
+    )
+    client = TestClient(configured.app)
+    created = client.post(
+        "/message:send",
+        headers={"A2A-Version": "1.0", "Authorization": f"Bearer {key_a}"},
+        json=_request("owned"),
+    )
+    assert created.status_code == 200, created.text
+    task_id = created.json()["task"]["id"]
+    own = client.get(
+        f"/tasks/{task_id}", headers={"A2A-Version": "1.0", "Authorization": f"Bearer {key_a}"}
+    )
+    assert own.status_code == 200
+    other = client.get(
+        f"/tasks/{task_id}", headers={"A2A-Version": "1.0", "Authorization": f"Bearer {key_b}"}
+    )
+    assert other.status_code == 404
+    assert "Task not found" in other.text

--- a/tests/test_a2a_connect.py
+++ b/tests/test_a2a_connect.py
@@ -257,6 +257,27 @@ def test_connect_a2a_inspect_prints_the_wire_log(tmp_path: Path, monkeypatch):
     assert "Chose JSONRPC 1.0" in result.output
     assert "skip JSONRPC 0.3" in result.output
     assert "later in preference" in result.output
+    assert "skills.attestation" in result.output
+    assert "Unattested Skill Claims" in result.output
+    assert "Card is unsigned" in result.output
+
+
+def test_connect_a2a_refuses_an_origin_off_the_allowlist(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("superqode.a2a.connection.connection_path", lambda: tmp_path / "a2a.json")
+    result = CliRunner().invoke(
+        connect,
+        [
+            "a2a",
+            "--url",
+            "http://agent",
+            "--allow-origin",
+            "safe.example",
+            "--json",
+            "--no-save",
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    assert "allowlist" in result.output
 
 
 def test_connect_a2a_inspect_explains_an_unspeakable_card(tmp_path: Path, monkeypatch):

--- a/tests/test_a2a_context.py
+++ b/tests/test_a2a_context.py
@@ -1,0 +1,69 @@
+"""Principal-bound A2A contextId ownership (A2ABreak)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from superqode.a2a.context import (
+    CONTEXT_OWNERSHIP_MESSAGE,
+    ContextOwnerStore,
+    ContextOwnershipError,
+    caller_principal,
+    request_principal,
+    valid_caller_key,
+)
+from superqode.a2a.keys import AccessDecision, OPERATOR_TIER
+
+
+def test_same_principal_can_reuse_a_context():
+    store = ContextOwnerStore()
+    store.claim("ctx-1", "key:alice")
+    store.claim("ctx-1", "key:alice")
+    assert store.owner_of("ctx-1") == "key:alice"
+
+
+def test_cross_principal_reuse_is_rejected():
+    store = ContextOwnerStore()
+    store.claim("ctx-1", "key:alice")
+    with pytest.raises(ContextOwnershipError, match="bound to another caller") as raised:
+        store.claim("ctx-1", "key:bob")
+    assert str(raised.value) == CONTEXT_OWNERSHIP_MESSAGE
+    assert raised.value.context_id == "ctx-1"
+
+
+def test_stored_owner_is_enforced_after_restart():
+    store = ContextOwnerStore()
+    with pytest.raises(ContextOwnershipError):
+        store.claim("ctx-1", "key:bob", stored_owner="key:alice")
+    store.claim("ctx-1", "key:alice", stored_owner="key:alice")
+    assert store.owner_of("ctx-1") == "key:alice"
+
+
+def test_request_principal_prefers_key_then_opaque_caller(monkeypatch):
+    request = SimpleNamespace(
+        headers={"x-superqode-caller-key": "alice-key-01", "x-forwarded-for": "1.2.3.4"},
+        client=SimpleNamespace(host="testclient"),
+    )
+    keyed = AccessDecision(True, "standard", key_id="abc123")
+    assert request_principal(keyed, request) == "key:abc123"
+    operator = AccessDecision(True, OPERATOR_TIER, customer="operator")
+    assert request_principal(operator, request) == "operator"
+    anonymous = AccessDecision(True, "anonymous")
+    assert request_principal(anonymous, request) == "caller:alice-key-01"
+    bare = SimpleNamespace(headers={}, client=SimpleNamespace(host="10.0.0.8"))
+    assert request_principal(anonymous, bare) == "ip:10.0.0.8"
+
+
+def test_caller_principal_reads_call_context_identity():
+    context = SimpleNamespace(
+        call_context=SimpleNamespace(state={"identity": "key:abc", "tier": "standard"})
+    )
+    assert caller_principal(context) == "key:abc"
+
+
+def test_valid_caller_key_matches_superoptix_shape():
+    assert valid_caller_key("alice-key-01")
+    assert not valid_caller_key("short")
+    assert not valid_caller_key("bad key!!")

--- a/tests/test_a2a_trust.py
+++ b/tests/test_a2a_trust.py
@@ -1,0 +1,125 @@
+"""A2ABreak Agent Card review: SuperOptiX wording, plus SuperQode extras."""
+
+from __future__ import annotations
+
+from superqode.a2a.trust import (
+    JWS_TRUST_ISSUE,
+    SKILLS_ATTESTATION_ISSUE,
+    UNSIGNED_SIGNATURE_ISSUE,
+    origin_is_allowed,
+    parse_origin_allowlist,
+    review_agent_card,
+)
+
+
+def _card(**extra):
+    payload = {
+        "name": "Demo",
+        "protocolVersion": "1.0",
+        "skills": [
+            {
+                "id": "s",
+                "name": "Skill",
+                "description": "A concrete skill description with enough text.",
+            }
+        ],
+        "url": "https://agent.example",
+        "supportedInterfaces": [
+            {
+                "url": "https://agent.example",
+                "protocolBinding": "JSONRPC",
+                "protocolVersion": "1.0",
+            }
+        ],
+        "securitySchemes": {"bearer": {"type": "http", "scheme": "bearer"}},
+    }
+    payload.update(extra)
+    return payload
+
+
+def test_unsigned_card_is_high_and_skills_are_unattested():
+    review = review_agent_card(_card())
+    fields = {item.field: item for item in review.findings}
+    assert "skills.attestation" in fields
+    assert fields["skills.attestation"].severity == "high"
+    assert fields["skills.attestation"].issue == SKILLS_ATTESTATION_ISSUE
+    assert "signature" in fields
+    assert fields["signature"].severity == "high"
+    assert fields["signature"].issue == UNSIGNED_SIGNATURE_ISSUE
+    assert "signature.trust" not in fields
+
+
+def test_signed_card_flags_jws_trust_model_gap():
+    review = review_agent_card(_card(signature={"protected": "x", "signature": "y"}))
+    fields = {item.field: item for item in review.findings}
+    assert "signature.trust" in fields
+    assert fields["signature.trust"].severity == "medium"
+    assert fields["signature.trust"].issue == JWS_TRUST_ISSUE
+    assert "signature" not in fields
+    assert any("JWS authenticates" in item.issue for item in review.findings)
+    assert any("Unattested Skill Claims" in item.issue for item in review.findings)
+
+
+def test_signatures_array_is_treated_as_present():
+    review = review_agent_card(_card(signatures=[{"protected": "x", "signature": "y"}]))
+    assert "signature.trust" in review.fields
+    assert "signature" not in review.fields
+
+
+def test_missing_security_schemes_uses_superoptix_wording():
+    card = _card()
+    card.pop("securitySchemes")
+    review = review_agent_card(card)
+    item = next(finding for finding in review.findings if finding.field == "securitySchemes")
+    assert item.severity == "medium"
+    assert "cannot tell how to authenticate" in item.issue
+
+
+def test_push_notifications_are_called_out():
+    review = review_agent_card(_card(capabilities={"pushNotifications": True}))
+    item = next(
+        finding for finding in review.findings if finding.field == "capabilities.pushNotifications"
+    )
+    assert "untrusted" in item.issue
+    assert "pushNotifications false" in item.issue
+
+
+def test_host_mismatch_is_reported():
+    review = review_agent_card(_card(), origin="https://discovery.example")
+    item = next(finding for finding in review.findings if finding.field == "url.host")
+    assert "agent.example" in item.issue
+    assert "discovery.example" in item.issue
+
+
+def test_allowlist_rejects_an_unlisted_origin():
+    assert origin_is_allowed("https://agent.example", ())
+    assert origin_is_allowed("https://agent.example", ("agent.example",))
+    assert not origin_is_allowed("https://evil.example", ("agent.example",))
+    review = review_agent_card(
+        _card(),
+        origin="https://evil.example",
+        allowed_origins=("agent.example",),
+    )
+    assert "origin.allowlist" in review.fields
+
+
+def test_parse_origin_allowlist_reads_cli_then_env(monkeypatch):
+    monkeypatch.setenv("SUPERQODE_A2A_ALLOWED_ORIGINS", "env.example, other.example")
+    assert parse_origin_allowlist(("cli.example",)) == (
+        "cli.example",
+        "env.example",
+        "other.example",
+    )
+
+
+def test_inspect_records_superoptix_findings():
+    from superqode.a2a.client import A2AClient
+
+    client = A2AClient("https://agent.example")
+    client._parse_agent_card(_card())
+    summaries = [event.summary for event in client.inspect.events if event.kind == "trust"]
+    assert any("skills.attestation" in line for line in summaries)
+    assert any("Unattested Skill Claims" in line for line in summaries)
+    assert any("signature:" in line or "signature " in line for line in summaries)
+    choice = client.inspect.events[-1]
+    assert choice.kind == "choice"

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -118,7 +118,10 @@ EXPECTED_COMMAND_COUNT = 280
 # Click command was added or removed and the count is unchanged.
 # Rebaselined for `superqode serve uhp`, which adds one Click command for a
 # native UHP Core bind of one SuperQode HarnessSpec (279 -> 280).
-EXPECTED_HELP_TREE_SHA256 = "5cc45e4360c108dc4f3abfe35d3004a12b6330e4f92f5d280a24066bb730d79d"
+# Rebaselined for `connect a2a --allow-origin` and `--jws-trust-root`, plus
+# inspect help naming card-review findings. Two new options on an existing
+# command, so the count is unchanged.
+EXPECTED_HELP_TREE_SHA256 = "4d7032c57e6291a84c620cc2b5f0e0b5e923387180160f63c6fe4602bf57362c"
 
 
 def _render_help_tree() -> tuple[int, str]:


### PR DESCRIPTION
## Summary

Harden SuperQode's A2A client and `serve a2a` against the first-wave A2ABreak findings ([arXiv:2609.10871](https://arxiv.org/abs/2609.10871)). These are protocol risks a spec-compliant adversary can exploit. They are not SuperQode product CVEs.

Mirrors SuperOptiX PR #11 card-review checklist wording as closely as SuperQode connect/inspect field names allow:

- `skills.attestation` (high): Skill claims are self-asserted. A2A 1.0 provides no attestation or capability challenge (A2ABreak protocol risk: Unattested Skill Claims).
- `signature` (high, existing): Card is unsigned. Signed cards are the A2A 1.0 mechanism for proving the card came from the domain owner.
- `signature.trust` (medium, when a JWS is present): JWS authenticates the card publisher, not skill capability. A signature does not attest that advertised skills are truthful (A2ABreak protocol risk: JWS Key Trust Model Gap).

### Client / inspect

- `superqode connect a2a --inspect` records card-review findings (including the SuperOptiX unattested-skill sentence whenever skills are advertised).
- `--allow-origin` / `SUPERQODE_A2A_ALLOWED_ORIGINS` refuse unlisted discovery origins before network work proceeds.
- `--jws-trust-root` / `SUPERQODE_A2A_JWS_TRUST_ROOT` configure a signature trust root. A JWS is never treated as authentication.

### Server (`serve a2a`)

Adapted for SuperQode principals, not SuperOptiX caller cookies:

- Isolate callers by API-key id, operator token, opaque `X-SuperQode-Caller-Key`, or the existing address identity.
- Same-principal `contextId` reuse is accepted so harness sessions keep working.
- Cross-principal client-supplied `contextId` is rejected.
- Official SDK List / Get / Cancel / Subscribe resolve the owner from that principal, so one caller cannot read or cancel another caller's tasks.

`pushNotifications: false` stays the default and mitigates the unverified-webhook finding.

### Deferred (not in this PR)

- Protocol principal tokens / multi-hop identity (do not forward an operator token or customer key).
- Skill attestation standards.
- Webhook ownership proofs.
- SuperOptiX-style ignore-and-mint of every client `contextId` (SuperQode binds instead).
- SuperOptiX caller cookies.

No release and no PyPI publish.

## Test plan

- [x] `uv run --extra a2a --extra dev pytest tests/test_a2a_trust.py tests/test_a2a_context.py tests/test_cli_contract.py tests/test_a2a_connect.py tests/test_a2a_bridge.py tests/test_a2a_security.py`
- [x] Cross-principal GetTask returns 404
- [x] Same-principal `contextId` reuse still works
- [x] `scripts/check_public_docs_style.py` (no em dashes)
- [ ] CI on this PR