### PR TITLE
docs: UHP A+B release-prep (no version bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+UHP is ready for a public package announcement: SuperQode speaks it as a client
+(connect, run, file upload and artifact download) and as a native Core server
+that binds one HarnessSpec. Harness stop reasons map to UHP failed or incomplete
+instead of an empty completed response. The same cut includes A2ABreak card-review
+and contextId hardening.
+
+### 🧩 Unified Harness Protocol
+
+- Client path: `superqode connect uhp` discovers a server and selects a harness;
+  `harness run uhp` runs tasks through the same session, event and evidence model
+  as a local harness.
+- File upload and artifact download: `--file` / `input_files=` send local files
+  through `POST /v1/files`; `--download-dir` and `download_citations` write
+  `container_file_citation` artifacts back to disk.
+- Native server: `superqode serve uhp --spec harness.yaml` exposes one configured
+  HarnessSpec over UHP Core. Complementary to HarnessRouter (a multi-backend
+  runner), not a substitute for it.
+- Harness `stopped_reason` values such as `error`, `blocked` and `loop_detected`
+  map to UHP `failed`; `needs_approval` and `max_iterations` map to `incomplete`.
+  An empty provider failure is no longer reported as `completed`.
+- The server advertises `conformance_class: core`. That names the surface it
+  implements; it is not a UHP conformance-suite certificate.
+
+### 🔐 A2ABreak hardening
+
+- Card review on connect/inspect surfaces SuperOptiX-aligned findings, and
+  `contextId` plus task ACL bind to the caller principal (protocol gaps, not
+  product CVEs).
+
 ## [2.2.0] - 2026-09-07
 
 Every Harness Hub record now states the language its harness is implemented in,

--- a/README.md
+++ b/README.md
@@ -317,6 +317,23 @@ superqode a2a-keys issue "Acme Corp" --tier one-off --days 30
 
 Read the [A2A guide](docs/providers/a2a.md).
 
+## Serve a Harness Over UHP
+
+The same install that drives a remote UHP server can also expose a local
+HarnessSpec so other UHP clients call SuperQode:
+
+```bash
+superqode serve uhp --spec harness.yaml --port 8787
+superqode connect uhp --base-url http://127.0.0.1:8787
+superqode harness run uhp --prompt "summarise this repository"
+```
+
+`serve uhp` binds one HarnessSpec and advertises UHP Core. It is complementary
+to HarnessRouter, which wraps third-party CLIs as a catalog. Core names the
+surface SuperQode implements; it is not a conformance-suite certificate.
+
+Read the [UHP guide](docs/providers/uhp.md).
+
 ## Harness Execution Model
 
 ```text
@@ -352,11 +369,12 @@ superqode harness graph <run-id> --json
 
 | Guide | What it covers |
 | --- | --- |
-| [Website](https://superqode.dev) | Product, Hub, A2A agent |
+| [Website](https://superqode.dev) | Product, Hub, A2A and UHP |
 | [Quick Start](https://docs.superqode.dev/getting-started/quickstart/) | Install, connect, and run your first task |
 | [Harness Hub](https://docs.superqode.dev/harness-hub/) | Browsing, filtering, and the published catalog |
-| [Connection Methods](docs/concepts/modes.md) | Local, ACP, BYOK, SDK, MCP, and A2A routes |
+| [Connection Methods](docs/concepts/modes.md) | Local, ACP, BYOK, SDK, MCP, A2A, and UHP routes |
 | [A2A Agents](docs/providers/a2a.md) | Serving a harness over A2A, skills, API keys, and the Agent Card |
+| [UHP](docs/providers/uhp.md) | Client connect/run, file upload, and native `serve uhp` (Core class) |
 | [Developer Workflows](docs/developer-workflows.md) | The complete TUI and CLI command set |
 | [Harness System](docs/advanced/harness-system.md) | HarnessSpec fields, runtimes, and policy |
 | [Harness Protocol](docs/advanced/harness-protocol.md) | The versioned session and evidence contract |

--- a/docs/concepts/modes.md
+++ b/docs/concepts/modes.md
@@ -64,6 +64,9 @@ Switching can preserve the current conversation or fork an independent branch:
 | A2A | Remote agents exposed through Agent2Agent endpoints | `:connect a2a` | The remote agent owns its execution contract |
 | UHP | Harnesses hosted on a Unified Harness Protocol server | `:connect uhp` | The server owns the harness, its tools, and its sandbox |
 
+SuperQode also serves UHP with `superqode serve uhp` (one HarnessSpec, Core
+class). See [Unified Harness Protocol](../providers/uhp.md).
+
 ### The Protocols screen
 
 ACP, A2A, and UHP all connect something that owns its own agent loop, so they

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -65,12 +65,14 @@ bundled ACP agent in one place.
 
     [:octicons-arrow-right-24: Runtime Backends](../runtimes.md)
 
--   **MCP and A2A**
+-   **MCP, A2A, and UHP**
 
-    Connect tool servers through MCP and remote agent services through A2A.
+    Connect tool servers through MCP, remote agents through A2A, and harnesses
+    through UHP (client and native `serve uhp`).
 
     [:octicons-arrow-right-24: MCP Configuration](../configuration/mcp-config.md)
     [:octicons-arrow-right-24: A2A Providers](a2a.md)
+    [:octicons-arrow-right-24: UHP](uhp.md)
 
 -   **Unified Harness Protocol**
 


### PR DESCRIPTION
## Summary
- Fill `CHANGELOG.md` `[Unreleased]` for UHP A+B: client connect/run with file upload and artifact download, native `superqode serve uhp` (Core, complementary to HarnessRouter), harness `stopped_reason` to UHP failed/incomplete, plus A2ABreak card-review / contextId.
- README: keep curl Quick Start first; add **Serve a Harness Over UHP** after A2A; link UHP in the docs table; honest Core-class (not conformance-suite) line.
- Light cross-links in `docs/concepts/modes.md` and `docs/providers/index.md`.

## Explicitly not in this PR
- No version bump (stays `2.2.0` in `pyproject.toml`)
- No tag, no PyPI publish, no release
- No Cloud connect polish, Extended files server, Hub bridge, public host, or conformance runner

## Test plan
- [x] `uv run python scripts/check_public_docs_style.py`
- [ ] Skim README Quick Start still leads with curl install
- [ ] Skim new UHP serve section and changelog Unreleased against `docs/providers/uhp.md`