### PR TITLE
chore(release): 2.2.1 local UHP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-UHP is ready for a public package announcement: SuperQode speaks it as a client
-(connect, run, file upload and artifact download) and as a native Core server
-that binds one HarnessSpec. Harness stop reasons map to UHP failed or incomplete
-instead of an empty completed response. The same cut includes A2ABreak card-review
-and contextId hardening.
+## [2.2.1] - 2026-09-12
+
+Local UHP for the package cut: SuperQode speaks it as a client (connect, run,
+file upload and artifact download) and as a native Core server that binds one
+HarnessSpec. Harness stop reasons map to UHP failed or incomplete instead of an
+empty completed response. The same cut includes A2ABreak card-review and
+contextId hardening. A public UHP host (GoDaddy) and Google Cloud infra stay for
+2.3.0.
 
 ### 🧩 Unified Harness Protocol
 

--- a/install/acp-registry/superqode/agent.json
+++ b/install/acp-registry/superqode/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "superqode",
   "name": "SuperQode",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "The open-source, terminal-first harness layer for coding agents. Build native harnesses or connect open-source and proprietary agents, models, and runtimes.",
   "repository": "https://github.com/SuperagenticAI/superqode",
   "website": "https://super-agentic.ai/superqode",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "distribution": {
     "uvx": {
-      "package": "superqode==2.2.0",
+      "package": "superqode==2.2.1",
       "args": [
         "serve",
         "acp"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "superqode"
-version = "2.2.0"
+version = "2.2.1"
 description = "The harness layer for coding agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/superqode/__init__.py
+++ b/src/superqode/__init__.py
@@ -38,7 +38,7 @@ __all__ = [
     "sidebar",
 ]
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 # Stable, lightweight public extension surface.  Importing this package does
 # not discover or execute third-party extensions; discovery happens only when

--- a/uv.lock
+++ b/uv.lock
@@ -23143,7 +23143,7 @@ wheels = [
 
 [[package]]
 name = "superqode"
-version = "2.2.0"
+version = "2.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary
- Bump SuperQode to **2.2.1** (pyproject, `__version__`, `uv.lock`, ACP registry)
- Promote CHANGELOG `[Unreleased]` to dated **2.2.1** (local UHP client + `serve uhp` Core + failure mapping + A2ABreak)
- Public UHP host (GoDaddy) and Google Cloud infra deferred to **2.3.0**

## After merge
Tag `v2.2.1` on main to trigger Publish (PyPI + GitHub Release).